### PR TITLE
feat: add cuda-nvcc to runner image for CUDA kernel compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,11 @@ on:
     - releases/*
     paths-ignore:
     - '**.md'
-    - 'images/**'
   pull_request:
     branches:
     - '**'
     paths-ignore:
     - '**.md'
-    - 'images/**'
 
 jobs:
   build:

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -6,11 +6,15 @@ FROM nvidia/cuda:12.2.0-base-ubuntu22.04 as base
 # Disable buffering for Python output
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/usr/local/cuda-12.2/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH}
 
 # Install system dependencies, including Python 3.10
 RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common \
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt-get update && apt-get install --allow-downgrades --allow-change-held-packages --no-install-recommends -y \
+    cuda-nvcc-12-2 \
+    cuda-cudart-dev-12-2 \
     build-essential \
     cmake \
     curl \


### PR DESCRIPTION
## Summary
Adds cuda-nvcc-12-2 and cuda-cudart-dev-12-2 packages to enable
compilation of CUDA kernels on H100 runners.

## Changes
- Install cuda-nvcc-12-2 (CUDA compiler)
- Install cuda-cudart-dev-12-2 (development headers)
- Set PATH and LD_LIBRARY_PATH for CUDA 12.2

## Why
The q8_kernels_ltx package requires nvcc to compile .cu files.
The current base image only has CUDA runtime, not the dev toolkit.

## Impact
- Image size: ~3.39 GB (+200-300 MB)
- Affects 6 runners:
  - h100
  - h100-ml-engine
  - l4
  - comfy-h100
  - h100-8g
  - xora-core-h100

## Testing
```
docker build -t cuda-arc-runner:test . --platform linux/amd64
docker run --rm cuda-arc-runner:test nvcc --version
# Cuda compilation tools, release 12.2, V12.2.140
```