### PR TITLE
ci: skip .NET tests for images/ changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,13 @@ on:
     - releases/*
     paths-ignore:
     - '**.md'
+    - 'images/**'
   pull_request:
     branches:
     - '**'
     paths-ignore:
     - '**.md'
+    - 'images/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Skip Runner CI (.NET tests) when only `images/` files are modified.

## Why
- Dockerfile changes don't affect .NET runner code
- Runner CI has been failing for 1+ year due to flaky network test
- This unblocks image updates from unrelated test failures

## Changes
Add `images/**` to `paths-ignore` in `build.yml` for both
`push` and `pull_request` triggers.